### PR TITLE
docs: fix LLM notes typos

### DIFF
--- a/huggingface-finetune-llm/lecture_nodes.md
+++ b/huggingface-finetune-llm/lecture_nodes.md
@@ -42,10 +42,10 @@ This page provides a step-by-step guide to fine-tuning the [deepseek-ai/DeepSeek
 
 SFT involves significant computational resources and engineering effort. When to use SFT?
 - need additional performance beyond the base model + prompt.
-- cost of llm outweights the cost of FT a small model.
-- require specialized formats or domain-sepcific knowledge.
+- cost of llm outweighs the cost of FT a small model.
+- require specialized formats or domain-specific knowledge.
 
-The datesets for fine-tuning should contain input prompt, expected model repsonse, and any additional metadata. 
+The datasets for fine-tuning should contain input prompt, expected model response, and any additional metadata.
 
 The Hugging Face tutorial provides sample codes by using the `SFTTrainer` class to fine-tune the model on a dataset. 
 

--- a/reading/docs/topics/Prompt/notes.md
+++ b/reading/docs/topics/Prompt/notes.md
@@ -8,7 +8,7 @@ It is a practice with a set of guidelines to craft precise, concise, creative wo
 
 ## Prompt Principles and Guides
 Refer to Paper [1]
-1. **Prompt Structure and Clarity**: Integrate the intended audience in teh prompt. e.g., integrate the intended audience in the prompt such as the audience is an expert in the field.
+1. **Prompt Structure and Clarity**: Integrate the intended audience in the prompt. e.g., integrate the intended audience in the prompt such as the audience is an expert in the field.
 2. **Specificity and Information**: Implement example-driven prompting. E.g., Add to your prompt the following phrase “Ensure that your answer is unbiased and does not rely on stereotypes.”;
 3. **User Interaction and Engagement**: Allow the model to ask precise details and requirements until it has enough information to provide the needed response. E.g. "From now on, I would like you to ask me questions to..."
 4. **Content and Language Stype**: Instruct the tone and style of response.

--- a/reading/docs/topics/compressing/notes.md
+++ b/reading/docs/topics/compressing/notes.md
@@ -22,7 +22,7 @@ Model compression aims to reduce the size of machine learning models without sac
 3. **Knowledge Distillation**: Training a smaller model to mimic the behavior of a larger model. 
 
 ## Quantization
-Lowering the precision of model paramters. Two common classes of quantization techniques:
+Lowering the precision of model parameters. Two common classes of quantization techniques:
 - Post-training quantization (PTQ)
 - Quantization-aware training (QAT)
 

--- a/reading/docs/topics/llm-as-judges/notes.md
+++ b/reading/docs/topics/llm-as-judges/notes.md
@@ -25,7 +25,7 @@ $$(Y, E, F) = f(T, C, X, R)$$
     - **Pointwise**: Evaluates each output independently based on specific criteria.
     - **Pairwise**: Compares two candidates to determine which one performs better according to the specified criteria. 
     - **Listwise**: Evaluates the entire list of candidate items, evaluating and ranking them based on the specific criteria, e.g. ranking tasks,
-- $C$ denotes the evaluation criteria, defining the specific standards that determine which aspects of the output should be assessed. Typically, teh criteria encompass the following aspects:
+- $C$ denotes the evaluation criteria, defining the specific standards that determine which aspects of the output should be assessed. Typically, the criteria encompass the following aspects:
     - **Linguistic Quality**: Language related of the output, e.g. fluency, grammatical accuracy, coherence, and conciseness.
     - **Content Relevance**: Focuses on correctness and relevance of the content. 
     - **Task-Specifc Criteria**: Customized criteria tailored to the specific task, e.g. creativity for story generation.


### PR DESCRIPTION
Problem: Several LLM study notes have visible spelling mistakes in prompt, fine-tuning, quantization, and LLM-as-judge sections.

Solution: Corrected the affected words, including `repsonse` -> `response`, `paramters` -> `parameters`, `teh` -> `the`, and nearby fine-tuning typos.

Validation:
- `git diff --check`
- `git grep -n -i repsonse -- '*.md'` returns no matches

Confidence: 85/100 (docs/typo).